### PR TITLE
Jcfreeman2/issue73 build info

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -312,6 +312,39 @@ endfunction()
 
 ####################################################################################################
 
+# _daq_gather_info:
+# Will take info both about the build and the source, and save it in a *.txt file
+
+function(_daq_gather_info)
+
+  set(cmds 
+	 "echo \"user for build:         $USER\""
+         "echo \"hostname for build:     $HOSTNAME\""
+	 "echo \"build time:             `date`\""
+	 "echo \"local repo dir:         `pwd`\""
+	 "echo \"git branch:             `git branch | sed -r 's/^..//'`\""
+	 "echo \"git commit hash:        `git log --pretty=\"%H\" -1`\"" 
+	 "echo \"git commit time:        `git log --pretty=\"%ad\" -1`\""
+	 "echo \"git commit description: `git log --pretty=\"%s\" -1`\""
+	 "echo \"git commit author:      `git log --pretty=\"%an\" -1`\""
+         "echo \"uncommitted changes:    `git diff HEAD --name-status | awk  '{print $2}' | sort -n | tr '\n' ' '`\""
+	 )
+
+	 set (fullcmd "")
+	 foreach( cmd ${cmds} )
+	   set(fullcmd "${fullcmd}${cmd}; ")
+	 endforeach()
+
+	 execute_process(COMMAND "bash" "-c" "${fullcmd}"  
+	 	         OUTPUT_FILE ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_build_info.txt 
+			 ERROR_FILE ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_build_info.txt  
+			 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+			 )
+
+endfunction()
+
+####################################################################################################
+
 # daq_install:
 # Usage:
 # daq_install()
@@ -321,6 +354,8 @@ endfunction()
 # arguments.
 
 function(daq_install) 
+
+  _daq_gather_info()		      
 
   ## AT HACK ALERT
   file(GLOB cmks CONFIGURE_DEPENDS cmake/*.cmake)

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -322,7 +322,7 @@ function(_daq_gather_info)
          "echo \"hostname for build:     $HOSTNAME\""
 	 "echo \"build time:             `date`\""
 	 "echo \"local repo dir:         `pwd`\""
-	 "echo \"git branch:             `git branch | sed -r 's/^..//'`\""
+	 "echo \"git branch:             `git branch | sed -r -n 's/^\\*.//p'`\""
 	 "echo \"git commit hash:        `git log --pretty=\"%H\" -1`\"" 
 	 "echo \"git commit time:        `git log --pretty=\"%ad\" -1`\""
 	 "echo \"git commit description: `git log --pretty=\"%s\" -1`\""


### PR DESCRIPTION
When a build is performed, a file of the form `<package name>_build_info.txt` for each repo in the work area will appear in the build directory, which will look something like the following:
<pre>
user for build:         jcfree
hostname for build:     mu2edaq13
build time:             Wed Dec  9 20:07:19 CST 2020
local repo dir:         /home/jcfree/daqbuild_build_info/sourcecode/cmdlib
git branch:             master
git commit hash:        26650f4b46f2b2e6316c1372afd5da8d2cc2b944
git commit time:        Sun Nov 22 17:01:18 2020 +0100
git commit description: Update UserGuide.md
git commit author:      Roland Sipos
uncommitted changes:    
</pre>
...where the significance of `uncommitted changes:` not having a value is that there aren't any files edited on top of Roland's commit in my local cmdlib build, otherwise an alphabetically-sorted list of edited files would appear 

Two questions:
-Any suggestions on what appears in the ASCII file?
-When the build is run with the `--install` option, what installation subdirectory should the file appear in?