### PR TITLE
Johnfreeman/issue16 debug vs optimized

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -37,7 +37,11 @@ macro(daq_setup_environment)
 
   set(DAQ_PROJECT_INSTALLS_TARGETS false)
 
-  add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
+  if (${DBT_DEBUG})
+    add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
+  else()
+    add_compile_options( -O2 -pedantic -Wall -Wextra -fdiagnostics-color=always )
+  endif()
 
   enable_testing()
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -40,7 +40,7 @@ macro(daq_setup_environment)
   if (${DBT_DEBUG})
     add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
   else()
-    add_compile_options( -O2 -pedantic -Wall -Wextra -fdiagnostics-color=always )
+    add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always -O2 )
   endif()
 
   enable_testing()


### PR DESCRIPTION
The `-O2` flag has been added to the default build. This can be observed by passing the `--verbose` argument to `build_daq_software.sh` or `dbt-build.sh`, whichever of the two you're using. 