### PR TITLE
Jcfreeman2/issue12 schema change rebuilds plugin v2

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -210,18 +210,6 @@ function(daq_add_plugin pluginname plugintype)
         file(MAKE_DIRECTORY ${outdir})
       endif()
 
-      moo_codegen(MPATH ${schemadir}
-                  TPATH ${schemadir}
-                  GRAFT /lang:ocpp.jsonnet
-		  TLAS  path=dunedaq.${PROJECT_NAME}.${pluginname_LC}
-		        ctxpath=dunedaq	
-		        os=${schemafile}
-       		  MODEL omodel.jsonnet
-  		  TEMPL o${WHAT_LC}.hpp.j2
-		  CODEGEN ${outdir}/${WHAT}.hpp
-		  CODEDEP ${schemadir}/${schemafile}
-		  TARGET ${pluginlibname})
-
       moo_associate(MPATH ${schemadir}
                     TPATH ${schemadir}
                     GRAFT /lang:ocpp.jsonnet

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -167,16 +167,31 @@ function(daq_add_plugin pluginname plugintype)
     set(PLUGIN_PATH "test/${PLUGIN_PATH}")
   endif()
   
-  # Before building anything, figure out if we need to generate code
-  # off of a schema
+  add_library( ${pluginlibname} MODULE ${PLUGIN_PATH}/${pluginname}.cpp)
+
+  target_link_libraries(${pluginlibname} ${PLUGOPTS_LINK_LIBRARIES}) 
+  target_include_directories(${pluginlibname} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> )
+
+  _daq_set_target_output_dirs( ${pluginlibname} ${PLUGIN_PATH} )
+
+  if ( ${PLUGOPTS_TEST} ) 
+    target_include_directories(${pluginlibname} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/src> )
+  else()
+    _daq_define_exportname()
+    install(TARGETS ${pluginlibname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
+  endif()
+
+  # Figure out if we need to generate code off of a schema and
+  # rebuild the plugin whenever the schema is edited
 
   if (${PLUGOPTS_SCHEMA})
 
-    set(schemadir ${PROJECT_SOURCE_DIR}/schema)
-    set(schemafile ${schemadir}/${PROJECT_NAME}-${pluginname}-schema.jsonnet)
+    set(schemadir  ${PROJECT_SOURCE_DIR}/schema)
+    set(schemafile ${PROJECT_NAME}-${pluginname}-schema.jsonnet)
 
-    if (NOT EXISTS ${schemafile})
-      message(FATAL_ERROR "Error: auto-generation of schema-based headers for plugin \"${pluginname}\" was requested, but required file ${schemafile} wasn't found")
+    if (NOT EXISTS ${schemadir}/${schemafile})
+      message(FATAL_ERROR "Error: auto-generation of schema-based headers for plugin \"${pluginname}\" was requested, but required file ${schemadir}/${schemafile} wasn't found")
     endif()
 
     foreach (WHAT Structs Nljs)
@@ -195,36 +210,22 @@ function(daq_add_plugin pluginname plugintype)
         file(MAKE_DIRECTORY ${outdir})
       endif()
 
-      moo_codegen(MPATH ${schemadir}
-                  TPATH ${schemadir}
-                  GRAFT /lang:ocpp.jsonnet
-                  TLAS  path=dunedaq.${PROJECT_NAME}.${pluginname_LC}
-                        ctxpath=dunedaq	
-                        os=${PROJECT_NAME}-${pluginname}-schema.jsonnet
-                  MODEL omodel.jsonnet
-                  TEMPL o${WHAT_LC}.hpp.j2
-                  CODEGEN ${outdir}/${WHAT}.hpp
-      )
+      moo_associate(MPATH ${schemadir}
+                    TPATH ${schemadir}
+                    GRAFT /lang:ocpp.jsonnet
+		    TLAS  path=dunedaq.${PROJECT_NAME}.${pluginname_LC}
+		          ctxpath=dunedaq	
+		          os=${schemafile}
+       		    MODEL omodel.jsonnet
+  		    TEMPL o${WHAT_LC}.hpp.j2
+		    CODEGEN ${outdir}/${WHAT}.hpp
+		    CODEDEP ${schemadir}/${schemafile}
+		    TARGET ${pluginlibname}
+	            )
     endforeach()
 
   endif()
 
-  add_library( ${pluginlibname} MODULE ${PLUGIN_PATH}/${pluginname}.cpp )
-  target_link_libraries(${pluginlibname} ${PLUGOPTS_LINK_LIBRARIES}) 
-  # Add src to the include path for private headers
-  target_include_directories(${pluginlibname} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> )
-
-  _daq_set_target_output_dirs( ${pluginlibname} ${PLUGIN_PATH} )
-
-
-  if ( ${PLUGOPTS_TEST} ) 
-    # Add test/src to the include path for private "test" headers
-    target_include_directories(${pluginlibname} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/src> )
-  else()
-    _daq_define_exportname()
-    install(TARGETS ${pluginlibname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
-  endif()
 
   endfunction()
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -210,6 +210,18 @@ function(daq_add_plugin pluginname plugintype)
         file(MAKE_DIRECTORY ${outdir})
       endif()
 
+      moo_codegen(MPATH ${schemadir}
+                  TPATH ${schemadir}
+                  GRAFT /lang:ocpp.jsonnet
+		  TLAS  path=dunedaq.${PROJECT_NAME}.${pluginname_LC}
+		        ctxpath=dunedaq	
+		        os=${schemafile}
+       		  MODEL omodel.jsonnet
+  		  TEMPL o${WHAT_LC}.hpp.j2
+		  CODEGEN ${outdir}/${WHAT}.hpp
+		  CODEDEP ${schemadir}/${schemafile}
+		  TARGET ${pluginlibname})
+
       moo_associate(MPATH ${schemadir}
                     TPATH ${schemadir}
                     GRAFT /lang:ocpp.jsonnet

--- a/cmake/moo.cmake
+++ b/cmake/moo.cmake
@@ -20,46 +20,6 @@ function(moo_deps_name source prefix)
   set("${prefix}_DEPS_NAME" "${DEPS_NAME}" PARENT_SCOPE)
 endfunction()
 
-##
-macro(moo_codegen)
-  cmake_parse_arguments(MC "" "MODEL;TEMPL;CODEGEN;MPATH;TPATH;GRAFT" "TLAS" ${ARGN})
-
-  if (NOT DEFINED MC_MPATH)
-    set(MC_MPATH ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-  if (NOT DEFINED MC_TPATH)
-    set(MC_TPATH ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-
-  set(MC_BASE_ARGS -T ${MC_TPATH} -M ${MC_MPATH})
-
-  if (DEFINED MC_GRAFT) 
-    list(APPEND MC_BASE_ARGS -g ${MC_GRAFT})
-  endif()
-  
-  if (DEFINED MC_TLAS)
-    foreach(TLA ${MC_TLAS})
-      list(APPEND MC_BASE_ARGS -A ${TLA})
-    endforeach()
-  endif()
-
-  set(MC_CODEGEN_ARGS ${MC_BASE_ARGS} render -o ${MC_CODEGEN} ${MC_MODEL} ${MC_TEMPL})
-
-  execute_process(
-    COMMAND ${MOO_CMD} ${MC_CODEGEN_ARGS}
-    RESULT_VARIABLE returnval 
-    OUTPUT_VARIABLE outvar 
-    ERROR_VARIABLE errvar 
-  )
-  if (NOT returnval EQUAL 0)
-    message(WARNING "WARNING: ${errvar}")
-    message(STATUS "Called ${MOO_CMD} ${MC_CODEGEN_ARGS}")
-    message(STATUS "Non-stderr output was ${outvar}")
-    message(FATAL_ERROR "Problem trying to generate ${MC_CODEGEN}")
-  endif()
-
-endmacro()
-
 macro(moo_associate)
   cmake_parse_arguments(MC "" "TARGET;CODEDEP;MODEL;TEMPL;CODEGEN;MPATH;TPATH;GRAFT" "TLAS" ${ARGN})
 


### PR DESCRIPTION
Have generation of a plugin's headers (Structs.hpp and Nljs.hpp) occur automatically when its schema file is modified, and the plugin itself rebuilt. CAUTION: some of the existing packages' builds may get broken by this pull request, if, e.g., their unit tests rely on a plugin's headers but the dependency of the unit test on the plugin hasn't been specified by `add_dependencies`