### PR TITLE
Johnfreeman/issue57 dont use nonexistent includedir

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -40,6 +40,7 @@ macro(daq_setup_environment)
   set(CMAKE_INSTALL_CONFIGDIR  ${CMAKE_INSTALL_DATADIR}/config ) # Not defined in GNUInstallDirs
 
   set(DAQ_PROJECT_INSTALLS_TARGETS false)
+  set(DAQ_PROJECT_GENERATES_CODE false)
 
   set(COMPILER_OPTS -g -pedantic -Wall -Wextra -fdiagnostics-color=always)
   if (${DBT_DEBUG})
@@ -282,6 +283,8 @@ function(daq_codegen)
     endforeach()
 
   endforeach()
+
+  set(DAQ_PROJECT_GENERATES_CODE true PARENT_SCOPE)
 endfunction()
 
 
@@ -339,9 +342,15 @@ function(daq_add_library)
     target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
     target_include_directories(${libname} PUBLIC 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
-      $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
     )
+
+    if (${DAQ_PROJECT_GENERATES_CODE})
+      target_include_directories(${libname} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
+      )
+    endif()
+
     target_include_directories(${libname} PRIVATE 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     )
@@ -352,9 +361,15 @@ function(daq_add_library)
     target_link_libraries(${libname} INTERFACE ${LIBOPTS_LINK_LIBRARIES})
     target_include_directories(${libname} INTERFACE 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include> 
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
+
+    if (${DAQ_PROJECT_GENERATES_CODE})
+      target_include_directories(${libname} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
+      )
+    endif()
+
   endif()
 
   _daq_define_exportname()
@@ -474,9 +489,15 @@ function(daq_add_python_bindings)
     target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
     target_include_directories(${libname} PUBLIC 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
-      $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
     )
+
+    if (${DAQ_PROJECT_GENERATES_CODE})
+      target_include_directories(${libname} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
+      )
+    endif()
+
     target_include_directories(${libname} PRIVATE 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     )

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -365,7 +365,7 @@ function(daq_add_library)
     )
 
     if (${DAQ_PROJECT_GENERATES_CODE})
-      target_include_directories(${libname} PUBLIC
+      target_include_directories(${libname} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CODEGEN_BINARY_DIR}/include>
       )
     endif()

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -340,10 +340,13 @@ function(daq_add_library)
   if (libsrcs)
     add_library(${libname} SHARED ${libsrcs})
     target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
-    target_include_directories(${libname} PUBLIC 
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
-    )
+
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+      target_include_directories(${libname} PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
+      )
+    endif()
 
     if (${DAQ_PROJECT_GENERATES_CODE})
       target_include_directories(${libname} PUBLIC
@@ -359,10 +362,13 @@ function(daq_add_library)
   else()
     add_library(${libname} INTERFACE)
     target_link_libraries(${libname} INTERFACE ${LIBOPTS_LINK_LIBRARIES})
-    target_include_directories(${libname} INTERFACE 
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
+
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+      target_include_directories(${libname} INTERFACE 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      )
+    endif()
 
     if (${DAQ_PROJECT_GENERATES_CODE})
       target_include_directories(${libname} INTERFACE
@@ -487,10 +493,13 @@ function(daq_add_python_bindings)
   if (libsrcs)
     pybind11_add_module(${libname} ${libsrcs})
     target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
-    target_include_directories(${libname} PUBLIC 
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
-    )
+
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+      target_include_directories(${libname} PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> 
+      )
+    endif()
 
     if (${DAQ_PROJECT_GENERATES_CODE})
       target_include_directories(${libname} PUBLIC


### PR DESCRIPTION
This PR addresses a problem Kurt ran into, which is this: if you link against a library (or more generally, a target) which you've built locally and which includes a nonexistent directory, you get an error. The specific problem was the dataformats library which included a nonexistent codegen directory in the build area. Now a codegen directory gets included in a package's library only if code is actually generated for that package; I've added this logic to entities which one might conceivably link against (so, not standalone applications or plugins). 