### PR TITLE
JCF: Issue #62: add the line Phil suggested to ensure that if a targe…

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -364,6 +364,8 @@ function(daq_add_library)
       )
     endif()
 
+    add_dependencies( ${libname} ${PRE_BUILD_STAGE_DONE_TRGT})
+
   endif()
 
   _daq_define_exportname()


### PR DESCRIPTION
…t links against an interface library, any generated headers from the package defining the interface library are guaranteed to exist when the target is built