### PR TITLE
Gracefully deal with non-git sourcecodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 2.1.1)
+project(daq-cmake VERSION 2.1.3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 2.0.2)
+project(daq-cmake VERSION 2.1.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -31,12 +31,12 @@ cat << EOF > ${SUMMARY_FILEPATH}
 \"hostname for build\":     \"$(hostname)\",
 \"build time\":             \"$(date)\",
 \"local repo dir\":         \"$(pwd)\",
-\"git branch\":             \"$(git branch | sed -r -n 's/^\\*.//p')\",
-\"git commit hash\":        \"$(git log --pretty=\"%H\" -1)\",
-\"git commit time\":        \"$(git log --pretty=\"%ad\" -1)\",
-\"git commit description\": \"$(git log --pretty=\"%s\" -1 | sed -r 's/\"/\\\\\"/g' )\",
-\"git commit author\":      \"$(git log --pretty=\"%an\" -1)\",
-\"uncommitted changes\":    \"$(git diff HEAD --name-status | awk  '{print $2}' | sort -n | tr '\\n' ' ')\"
+\"git branch\":             \"$( (git rev-parse 2>/dev/null && git branch | sed -r -n 's/^\\*.//p') || echo 'no git repo found' )\",
+\"git commit hash\":        \"$( (git rev-parse 2>/dev/null && git log --pretty=\"%H\" -1)  || echo 'no git repo found' )\",
+\"git commit time\":        \"$( (git rev-parse 2>/dev/null && git log --pretty=\"%ad\" -1)  || echo 'no git repo found' )\",
+\"git commit description\": \"$( (git rev-parse 2>/dev/null && git log --pretty=\"%s\" -1 | sed -r 's/\"/\\\\\"/g' ) || echo 'no git repo found' )\",
+\"git commit author\":      \"$( (git rev-parse 2>/dev/null && git log --pretty=\"%an\" -1)  || echo 'no git repo found' )\",
+\"uncommitted changes\":    \"$( (git rev-parse 2>/dev/null && git diff HEAD --name-status | awk  '{print $2}' | sort -n | tr '\\n' ' ' ) || echo 'no git repo found')\"
 }
 EOF
 ")

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -42,7 +42,7 @@ EOF
 YELLOW=\"\\033[0;33m\"
 PURPLE=\"\\033[0;35m\"
 NC=\"\\033[0m\"
-git rev-parse --is-inside-work-tree > /dev/null 2>&1|| printf \"\${YELLOW}Warning: local source code directory \${PURPLE} \$(pwd) \${YELLOW} is not inside a git repo work tree \${NC}\n\"
+git rev-parse --is-inside-work-tree > /dev/null 2>&1|| printf \"\${YELLOW}Warning: local source code directory \${PURPLE}\$(pwd)\${YELLOW} is not inside a git repo work tree.\${NC}\n\"
 
 ")
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -39,7 +39,13 @@ cat << EOF > ${SUMMARY_FILEPATH}
 \"uncommitted changes\":    \"$( (git rev-parse 2>/dev/null && git diff HEAD --name-status | awk  '{print $2}' | sort -n | tr '\\n' ' ' ) || echo 'no git repo found')\"
 }
 EOF
+YELLOW=\"\\033[0;33m\"
+PURPLE=\"\\033[0;35m\"
+NC=\"\\033[0m\"
+git rev-parse --is-inside-work-tree > /dev/null 2>&1|| printf \"\${YELLOW}Warning: local source code directory \${PURPLE} \$(pwd) \${YELLOW} is not inside a git repo work tree \${NC}\n\"
+
 ")
+
 
   add_custom_command(
     OUTPUT ${DAQ_PROJECT_SUMMARY_PHONY_TARGET}


### PR DESCRIPTION
Notwithstanding that non-revisioned packages are discouraged, `dbt` should gracefully cope with cases where a package is not a git repository. This PR adds extra checks to the `gather_info` script to avoid long and hard-to-decode git error messages when trying to retrieve the repository status.