### PR TITLE
Johnfreeman/issue108 add gordons daldir argument

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -510,8 +510,8 @@ endfunction()
 #######################################################################
 
 function(daq_oks_codegen)
-
-   cmake_parse_arguments(config_opts "" "NAMESPACE" "DEP_PKGS" ${ARGN})
+   set(oneValueArgs NAMESPACE DALDIR)
+   cmake_parse_arguments(config_opts "" "${oneValueArgs}" "DEP_PKGS" ${ARGN})
 
    set(srcs ${config_opts_UNPARSED_ARGUMENTS})
 
@@ -528,7 +528,11 @@ function(daq_oks_codegen)
    set(LIST GENCONFIG_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/genconfig_${TARGETNAME}/ )
 
    set(cpp_dir ${CMAKE_CODEGEN_BINARY_DIR}/src)
-   set(hpp_dir ${CMAKE_CODEGEN_BINARY_DIR}/include/${PROJECT_NAME})
+   if(NOT config_opts_DALDIR)
+     set(hpp_dir ${PROJECT_NAME})
+   else()
+     set(hpp_dir ${config_opts_DALDIR})
+   endif()
 
    set(NAMESPACE)
    if(NOT config_opts_NAMESPACE)

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -506,7 +506,7 @@ endfunction()
 #
 # NAMESPACE: the namespace in which the generated C++ classes will be in. Defaults to `dunedaq::<package>`
 #
-# DALDIR: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`; default is no subdirectory
+# DALDIR: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`); default is no subdirectory
 #
 # DEP_PKGS: if a schema file you've provided as an argument itself includes a schema file (or schema files) from one or more other packages, you need to supply the names of the packages as arguments to DEP_PKGS. 
 #

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -493,7 +493,8 @@ endfunction()
 
 # ######################################################################
 # daq_oks_codegen(<oks schema filename1> ... 
-#                      [NAMESPACE ns] 
+#                      [NAMESPACE ns]
+#                      [DALDIR subdir]
 #		       [DEP_PKGS pkg1 pkg2 ...]
 #
 # `daq_oks_codegen` uses the genconfig package's application of the same
@@ -504,6 +505,8 @@ endfunction()
 #  <schema filename1> ...: the list of OKS schema files to process from `<package>/schema/<package>`. 
 #
 # NAMESPACE: the namespace in which the generated C++ classes will be in. Defaults to `dunedaq::<package>`
+#
+# DALDIR: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`; default is no subdirectory
 #
 # DEP_PKGS: if a schema file you've provided as an argument itself includes a schema file (or schema files) from one or more other packages, you need to supply the names of the packages as arguments to DEP_PKGS. 
 #
@@ -517,8 +520,8 @@ endfunction()
 #######################################################################
 
 function(daq_oks_codegen)
-   set(oneValueArgs NAMESPACE DALDIR)
-   cmake_parse_arguments(config_opts "" "${oneValueArgs}" "DEP_PKGS" ${ARGN})
+
+   cmake_parse_arguments(config_opts "" "NAMESPACE;DALDIR" "DEP_PKGS" ${ARGN})
 
    set(srcs ${config_opts_UNPARSED_ARGUMENTS})
 
@@ -534,12 +537,19 @@ function(daq_oks_codegen)
 
    set(LIST GENCONFIG_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/genconfig_${TARGETNAME}/ )
 
-   set(cpp_dir ${CMAKE_CODEGEN_BINARY_DIR}/src)
-   if(NOT config_opts_DALDIR)
-     set(hpp_dir ${PROJECT_NAME})
-   else()
-     set(hpp_dir ${config_opts_DALDIR})
+   set(hpp_dir_prefix ${CMAKE_CODEGEN_BINARY_DIR}/include )
+
+   set(hpp_dir_relative ${PROJECT_NAME})
+   if(config_opts_DALDIR)
+     if(config_opts_DALDIR MATCHES "^${PROJECT_NAME}/")
+       message(WARNING "The DALDIR subdirectory passed to this function begins with \"${PROJECT_NAME}/\"; this is probably not what you want as the subdirectory is taken as relative to ${hpp_dir_prefix}/${hpp_dir_relative}")
+     endif()
+
+     set(hpp_dir_relative ${hpp_dir_relative}/${config_opts_DALDIR})
    endif()
+
+   set(hpp_dir ${hpp_dir_prefix}/${hpp_dir_relative})
+   set(cpp_dir ${CMAKE_CODEGEN_BINARY_DIR}/src)
 
    set(NAMESPACE)
    if(NOT config_opts_NAMESPACE)
@@ -615,7 +625,7 @@ function(daq_oks_codegen)
    add_custom_command(
      OUTPUT ${cpp_source} genconfig_${TARGETNAME}/genconfig.info 
      COMMAND mkdir -p ${cpp_dir} ${hpp_dir} genconfig_${TARGETNAME}
-     COMMAND ${CMAKE_COMMAND} -E env DUNEDAQ_SHARE_PATH=${PATHS_TO_SEARCH} ${GENCONFIG_BINARY} -i ${PROJECT_NAME} -n ${NAMESPACE} -d ${cpp_dir} -p ${PROJECT_NAME}  -I ${GENCONFIG_INCLUDES} -s ${schemas}
+     COMMAND ${CMAKE_COMMAND} -E env DUNEDAQ_SHARE_PATH=${PATHS_TO_SEARCH} ${GENCONFIG_BINARY} -i ${hpp_dir_relative} -n ${NAMESPACE} -d ${cpp_dir} -p ${PROJECT_NAME}  -I ${GENCONFIG_INCLUDES} -s ${schemas}
      COMMAND cp -f ${cpp_dir}/*.hpp ${hpp_dir}/
      COMMAND cp genconfig.info genconfig_${TARGETNAME}/
      DEPENDS ${schemas} ${config_dependencies} ${GENCONFIG_DEPENDS} 
@@ -624,7 +634,6 @@ function(daq_oks_codegen)
    add_custom_target(${TARGETNAME} ALL DEPENDS ${cpp_source} genconfig_${TARGETNAME}/genconfig.info)
    add_dependencies( ${PRE_BUILD_STAGE_DONE_TRGT} ${TARGETNAME})
 
-   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${hpp_dir} DESTINATION include FILES_MATCHING PATTERN *.hpp)
    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/genconfig_${TARGETNAME} DESTINATION ${CMAKE_INSTALL_DATADIR})
 
   set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -390,7 +390,7 @@ token.
 ### daq_oks_codegen
 Usage:
 ```
-daq_oks_codegen(<oks schema filename1> ... [NAMESPACE ns] [DEP_PKGS pkg1 pkg2 ...])
+daq_oks_codegen(<oks schema filename1> ... [NAMESPACE ns] [DALDIR subdir] [DEP_PKGS pkg1 pkg2 ...])
 ```
 
 `daq_oks_codegen` uses the genconfig package's application of the same
@@ -403,7 +403,7 @@ Arguments:
 
  `NAMESPACE`: the namespace in which the generated C++ classes will be in. Defaults to `dunedaq::<package>`
 
- `DALDIR`: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`; default is no subdirectory
+ `DALDIR`: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`); default is no subdirectory
 
  `DEP_PKGS`: if a schema file you've provided as an argument itself includes a schema file (or schema files) from one or more other packages, you need to supply the names of the packages as arguments to DEP_PKGS. 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -403,6 +403,8 @@ Arguments:
 
  `NAMESPACE`: the namespace in which the generated C++ classes will be in. Defaults to `dunedaq::<package>`
 
+ `DALDIR`: subdirectory relative to the package's primary include directory where headers will appear (`include/<package>/<DALDIR argument>`; default is no subdirectory
+
  `DEP_PKGS`: if a schema file you've provided as an argument itself includes a schema file (or schema files) from one or more other packages, you need to supply the names of the packages as arguments to DEP_PKGS. 
 
 The generated code is automatically built into the package's main


### PR DESCRIPTION
This PR adds the `DALDIR` argument which Gordon created for `daq_oks_codegen`. A couple of quick points:

1) How to use `DALDIR` is quite simple, and documented in https://github.com/DUNE-DAQ/daq-cmake/tree/johnfreeman/issue108_add_gordons_DALDIR_argument#daq_oks_codegen

2) I changed the semantics of the `DALDIR` argument so that the subdirectory you pass is taken as relative to `include/<packagename>` in a package rather than simply `include/`. This is because all public headers should be at the same or a lower level in the tree structure than `include/<packagename>`. So, e.g., 
`daq_oks_codegen(listrev.schema.xml NAMESPACE dunedaq::listrev::dal  DALDIR listrev/dal DEP_PKGS coredal)`
becomes
`daq_oks_codegen(listrev.schema.xml NAMESPACE dunedaq::listrev::dal  DALDIR dal DEP_PKGS coredal)`

3) Both locally and as part of a Spack build, I was able to use this feature branch of `daq-cmake` to build `appdal`, `coredal`, `appfwk` and `listrev` on feature branches of the same name (i.e. `johnfreeman/issue108_add_gordons_DALDIR_argument`). Please note that this is a bit overengineered in the sense that `coredal` and `appdal` on these feature branches _have the same code_ as on their `develop` branches. A test release of this build is at `NAFDT23-11-29` 