### PR TITLE
AJM: Bump version in CMakeLists to 2.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 2.7.0)
+project(daq-cmake VERSION 2.7.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)


### PR DESCRIPTION
This version will includes fixes to Issue #118 and Issue #119. These fixes only apply to `create_dunedaq_package` when using `daqconf`, and so will only go into the `production/v4` line, not `develop` (aka `v5`). 