### PR TITLE
JCF: bump daq-cmake to v2.8.0; intended for the v5 development line t…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 2.7.2)
+project(daq-cmake VERSION 2.8.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)


### PR DESCRIPTION
…his provides support for DUNEDAQ_DB_PATH (see daq-buildtools/DUNE-DAQ#273)