### PR TITLE
JCF: bump tag for daq-cmake compatible with externals v2.2 versions o…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 3.0.2)
+project(daq-cmake VERSION 3.0.3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)


### PR DESCRIPTION
…f gcc and folly