### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/toylibrary/test/apps/toylibrary_test_program.cxx
+++ b/toylibrary/test/apps/toylibrary_test_program.cxx
@@ -15,7 +15,7 @@
 
 #include "toylibrary/IntPrinter.hpp"
 
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <boost/program_options.hpp>
 

--- a/toylibrary/test/apps/toylibrary_test_program.cxx
+++ b/toylibrary/test/apps/toylibrary_test_program.cxx
@@ -15,7 +15,7 @@
 
 #include "toylibrary/IntPrinter.hpp"
 
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <boost/program_options.hpp>
 


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)