### PR TITLE
JCF: bump daq-cmake version tag to 3.0.5; this includes the fix from …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daq-cmake VERSION 3.0.4)
+project(daq-cmake VERSION 3.0.5)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(DAQ)


### PR DESCRIPTION
…Issue #152