### PR TITLE
Johnfreeman/issue161 integtest skeleton

### DIFF
--- a/config/templates/renameme_test.py
+++ b/config/templates/renameme_test.py
@@ -4,8 +4,22 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 
-# Use the integrationtest_drunc plugin
 pytest_plugins = "integrationtest.integrationtest_drunc" 
+
+# Values which we'll compare the results to in order to determine success or failure
+expected_number_of_data_files = 1
+
+
+ignored_logfile_problems = {
+    "-controller": [
+        "Worker with pid \\d+ was terminated due to signal",
+        "Connection '.*' not found on the application registry",
+    ],
+    "connectivity-service": [
+        "errorlog: -",
+    ],
+}
+
 
 # Load pre-configured objects from this OKS database file
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
@@ -16,24 +30,27 @@ config_obj  = data_classes.drunc_config()
 # Declare the set of configurations to be tested, as a dictionary of name: drunc_config() pairs or as a list of drunc_config() objects
 confgen_arguments = [config_obj]
 
-# The commands to run in nanorc, as a list (this is read by integrationtest_drunc)
+# The commands for run control to run, as a list (this is read by integrationtest_drunc).
 nanorc_command_list="boot conf start --run-number 1 enable-triggers wait 10 disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
 
 # The tests themselves
 
 def test_nanorc_success(run_nanorc):
-    # Check that nanorc completed correctly
+    # Check that run control returned zero (i.e., completed without an error value)
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-    # Check that there are no warnings or errors in the log files
-    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+
+    assert log_file_checks.logs_are_error_free(run_nanorc.log_files,
+                                               show_all_problems=True,
+                                               print_logfilename_for_problems=True,
+                                               excluded_substring_map=ignored_logfile_problems
+                                               )
+                                               
 
 def test_data_file(run_nanorc):
-    # Run some tests on the output data file
-    assert len(run_nanorc.data_files)==1
+
+    assert len(run_nanorc.data_files)==expected_number_of_data_files
 
     data_file=data_file_checks.DataFile(run_nanorc.data_files[0])
     assert data_file_checks.sanity_check(data_file)
-    assert data_file_checks.check_link_presence(data_file, n_links=1)
-    assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=22344, max_frag_size=22344)

--- a/config/templates/renameme_test.py
+++ b/config/templates/renameme_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.log_file_checks as log_file_checks
+import integrationtest.data_classes as data_classes
+
+# Use the integrationtest_drunc plugin
+pytest_plugins = "integrationtest.integrationtest_drunc" 
+
+# Load pre-configured objects from this OKS database file
+object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
+
+# Create a meta-configuration. This is used by integrationtest_drunc to configure daqconf
+config_obj  = data_classes.drunc_config()
+
+# Declare the set of configurations to be tested, as a dictionary of name: drunc_config() pairs or as a list of drunc_config() objects
+confgen_arguments = [config_obj]
+
+# The commands to run in nanorc, as a list (this is read by integrationtest_drunc)
+nanorc_command_list="boot conf start --run-number 1 enable-triggers wait 10 disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
+
+# The tests themselves
+
+def test_nanorc_success(run_nanorc):
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode==0
+
+def test_log_files(run_nanorc):
+    # Check that there are no warnings or errors in the log files
+    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+
+def test_data_file(run_nanorc):
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files)==1
+
+    data_file=data_file_checks.DataFile(run_nanorc.data_files[0])
+    assert data_file_checks.sanity_check(data_file)
+    assert data_file_checks.check_link_presence(data_file, n_links=1)
+    assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=22344, max_frag_size=22344)

--- a/config/templates/renameme_test.py
+++ b/config/templates/renameme_test.py
@@ -6,9 +6,25 @@ import integrationtest.data_classes as data_classes
 
 pytest_plugins = "integrationtest.integrationtest_drunc" 
 
+# Values that help determine the running conditions
+run_duration = 10 # seconds
+number_of_data_producers = 1
+trigger_rate_hz = 1
+
 # Values which we'll compare the results to in order to determine success or failure
 expected_number_of_data_files = 1
+expected_event_count = run_duration
+expected_event_count_tolerance = 2
 
+######################################################################
+#
+# Developer can add tests on fragments here by creating Python
+# dictionaries with names of the form *_frag_params. See existing
+# integration tests in, e.g., daqsystemtest for more.
+#
+# Please delete this comment when this has been accomplished
+#
+######################################################################
 
 ignored_logfile_problems = {
     "-controller": [
@@ -26,12 +42,34 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
 # Create a meta-configuration. This is used by integrationtest_drunc to configure daqconf
 config_obj  = data_classes.drunc_config()
+config_obj.dro_map_config.n_streams = number_of_data_producers
+config_obj.op_env = "integtest"
+config_obj.session = "renameme"
+config_obj.tpg_enabled = False
+config_obj.fake_hsi_enabled = False
+
+config_obj.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="RandomTCMakerConf",
+        updates={"trigger_rate_hz": trigger_rate_hz},
+    )
+)
+
+######################################################################
+#
+# Developer can add further changes to config_obj here. See existing
+# integration tests in, e.g., daqsystemtest for more
+#
+# Please delete this comment when this has been accomplished
+#
+######################################################################
+
 
 # Declare the set of configurations to be tested, as a dictionary of name: drunc_config() pairs or as a list of drunc_config() objects
 confgen_arguments = [config_obj]
 
 # The commands for run control to run, as a list (this is read by integrationtest_drunc).
-nanorc_command_list="boot conf start --run-number 1 enable-triggers wait 10 disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
+nanorc_command_list=f"boot conf start --run-number 101 enable-triggers wait {run_duration} disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
 
 # The tests themselves
 
@@ -40,17 +78,30 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-
     assert log_file_checks.logs_are_error_free(run_nanorc.log_files,
                                                show_all_problems=True,
                                                print_logfilename_for_problems=True,
                                                excluded_substring_map=ignored_logfile_problems
                                                )
-                                               
 
-def test_data_file(run_nanorc):
+def test_data_files(run_nanorc):
 
     assert len(run_nanorc.data_files)==expected_number_of_data_files
 
     data_file=data_file_checks.DataFile(run_nanorc.data_files[0])
     assert data_file_checks.sanity_check(data_file)
+
+    all_ok = True
+    for filename in run_nanorc.data_files:
+        data_file = data_file_checks.DataFile(filename)
+        all_ok &= data_file_checks.sanity_check(data_file)
+        all_ok &= data_file_checks.check_file_attributes(data_file)
+        all_ok &= data_file_checks.check_event_count(
+            data_file, expected_event_count, expected_event_count_tolerance
+        )
+
+    # Can also add fragment checks here (# of fragments, their sizes,
+    # etc.). See existing integration tests in, e.g., daqsystemtest
+    # for more
+
+    assert all_ok

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@ Arguments and options:
 
 `--test-app`: same as `--daq-module`, but for integration test applications
 
+`--pytest`: will create a Python program readable by the pytest integration test framework
+
 Note that some of these concepts, e.g. a user-oriented app vs. an app designed for integration tests of the package itself, are covered below in the [Overview of a DUNE DAQ package](#package_overview) section.
 
 In the directory `create_dunedaq_package` is run out of, `create_dunedaq_package` will create a subdirectory named after your package if such a subdirectory doesn't exist. If a subdirectory with that name already _does_ exist, it should be empty with the possible exceptions of a `README.md` documentation file and/or a `.git/` version control directory. These exceptions allow you to run the script using as an argument the name of a new repo which you've cloned into your area. An example of using `create_dunedaq_package` would be the following (note you can horizontal-scroll the command below):

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Arguments and options:
 
 `--test-app`: same as `--daq-module`, but for integration test applications
 
-`--pytest`: will create a Python program readable by the pytest integration test framework
+`--pytest`: will create a Python program readable by the [pytest integration test framework](https://docs.pytest.org/en/stable/). It takes the name of the test as an argument; note the name needs to be of the form `*_test` or `test_*` so that pytest can work with it. 
 
 Note that some of these concepts, e.g. a user-oriented app vs. an app designed for integration tests of the package itself, are covered below in the [Overview of a DUNE DAQ package](#package_overview) section.
 

--- a/scripts/create_dunedaq_package
+++ b/scripts/create_dunedaq_package
@@ -139,9 +139,9 @@ else:
         if file_in_dir != ".git" and file_in_dir != "README.md" and file_in_dir != "docs":
             error(f"""
 
-It looks like this directory isn't empty. This script can only be run in 
-directories which are empty with the possible exceptions of a .git/ subdirectory
-and/or a README.md documentation file. 
+It looks like the directory \"{PACKAGEDIR}\" isn't empty.
+This script can only be run for directories which are empty with the possible exceptions
+of a .git/ subdirectory and/or a README.md documentation file.
 
     """)
 
@@ -202,7 +202,7 @@ for more on naming conventions. Exiting...
             wipe_package_directory()
             error(f"""
 Requested pytest name \"{pytest}\" is invalid; it needs to be of the form
-\"*_test.py\" or \"test_*.py\" to get picked up by pytest. Please see
+\"*_test\" or \"test_*\" to get picked up by pytest. Please see
 https://dune-daq-sw.readthedocs.io/en/latest/packages/integrationtest/ for
 more. Exiting...
 """)
@@ -211,7 +211,23 @@ more. Exiting...
         DEST_FILENAME = src_filename.replace("renameme_test", pytest)
         DEST_FILENAME = f"{PACKAGEDIR}/integtest/{DEST_FILENAME}"
 
-        shutil.copyfile(f"{TEMPLATEDIR}/{src_filename}", DEST_FILENAME)
+        with open(f"{TEMPLATEDIR}/{src_filename}", "r") as inf:
+            session_name = "UNDEFINED"
+            res = re.search(r".*/(.*)_test.py", DEST_FILENAME)
+            if res:
+                session_name = res.group(1)
+            else:
+                res = re.search(r".*/test_(.*).py", DEST_FILENAME)
+                if res:
+                    session_name = res.group(1)
+                else:
+                    assert False, f"Unable to determine session name from filename \"{DEST_FILENAME}\""
+
+            sourcecode = inf.read()
+            sourcecode = sourcecode.replace("renameme", session_name)
+
+            with open(DEST_FILENAME, "w") as outf:
+                outf.write(sourcecode)
 
 if args.daq_modules:
 

--- a/scripts/create_dunedaq_package
+++ b/scripts/create_dunedaq_package
@@ -49,6 +49,9 @@ Arguments and options:
 
 --test-app: same as --daq-module, but for integration test applications
 
+--pytest: for each "--pytest <test name>" provided at the command line, the 
+          framework for a pytest integration test will be auto-generated
+
 For details on how to write a DUNE DAQ package, please look at the official 
 daq-cmake documentation at 
 https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
@@ -62,6 +65,7 @@ parser.add_argument("--daq-module", action="append", dest="daq_modules", help=ar
 parser.add_argument("--user-app", action="append", dest="user_apps", help=argparse.SUPPRESS)
 parser.add_argument("--test-app", action="append", dest="test_apps", help=argparse.SUPPRESS)
 parser.add_argument("--config-generation", action="store_true", dest="contains_config_generation", help=argparse.SUPPRESS)
+parser.add_argument("--pytest", action="append", dest="pytests", help=argparse.SUPPRESS)
 parser.add_argument("package", nargs="?", help=argparse.SUPPRESS)
 
 args = parser.parse_args()
@@ -182,6 +186,32 @@ if args.contains_python_bindings:
         with open(f"{PACKAGEDIR}/python/{PACKAGE}/{src_filename}", "w") as outf:
             outf.write(sourcecode)
 
+if args.pytests:
+    make_package_subdir(f"{PACKAGEDIR}/integtest")
+
+    for pytest in args.pytests:
+
+        if re.search(r"[A-Z]", pytest):
+            wipe_package_directory()
+            error(f"""
+Requested pytest name \"{pytest}\" needs to be in snake_case. 
+Please see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/ 
+for more on naming conventions. Exiting...
+""")
+        if "test" not in pytest:
+            wipe_package_directory()
+            error(f"""
+Requested pytest name \"{pytest}\" is invalid; it needs to be of the form
+\"*_test.py\" or \"test_*.py\" to get picked up by pytest. Please see
+https://dune-daq-sw.readthedocs.io/en/latest/packages/integrationtest/ for
+more. Exiting...
+""")
+
+        src_filename = "renameme_test.py"
+        DEST_FILENAME = src_filename.replace("renameme_test", pytest)
+        DEST_FILENAME = f"{PACKAGEDIR}/integtest/{DEST_FILENAME}"
+
+        shutil.copyfile(f"{TEMPLATEDIR}/{src_filename}", DEST_FILENAME)
 
 if args.daq_modules:
 


### PR DESCRIPTION
This PR adds a `--pytest` argument to `create_dunedaq_package`. How to use it can be found in the updated documentation on this feature branch: https://github.com/DUNE-DAQ/daq-cmake/tree/johnfreeman/issue161_integtest_skeleton?tab=readme-ov-file#the-create_dunedaq_package-script

Please note that to get your hands on the updated `create_dunedaq_package`, you'll want to build `daq-cmake` off this feature branch in a local work area just as with any other repository.

Also note that it's a bit of an open question just how "skeletal" we want to make the created pytest integration test. If you look at `config/templates/renameme_test.py` you'll see that I added some basics (e.g., a single data producer which produces one fragment per second) and in fact the integration test generated by `create_dunedaq_package` can be run as-is. However, I left out explicit fragment definitions, my reasoning being that (1) I don't know what fragments users ultimately will want in their test and (2) there's a major risk that in defining things like "expected fragment size" that the test will fall out of sync over time. In particular, I don't like the idea that whenever expected fragment sizes change, a new version of daq-cmake would need to be cut. 