### PR TITLE
JCF: on James Paul Turner's recommendation, generate pybind11-stubgen…

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -910,8 +910,26 @@ function(daq_add_python_bindings)
     message(FATAL_ERROR "ERROR: No source files found for python library: ${libname}.")
   endif()
 
+  find_program(PYBIND11_STUBGEN pybind11-stubgen)
+
+  if(PYBIND11_STUBGEN)
+    execute_process(
+      COMMAND ${PYBIND11_STUBGEN} -o ${PROJECT_NAME}/python ${PROJECT_NAME}
+      RESULT_VARIABLE retval
+      ERROR_VARIABLE errmsg
+    )
+
+    if(retval)
+      message(WARNING
+	"pybind11-stubgen failed for ${PROJECT_NAME}.\n"
+	"${errmsg}\n"
+	"The Python buildings were build successfully, but pybind11-stubgen was unable to generate stubs.")
+    endif()
+  endif()
+
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} OPTIONAL FILES_MATCHING PATTERN "*.pyi")
   set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
 
 endfunction()

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -923,13 +923,13 @@ function(daq_add_python_bindings)
       message(WARNING
 	"pybind11-stubgen failed for ${PROJECT_NAME}.\n"
 	"${errmsg}\n"
-	"The Python buildings were build successfully, but pybind11-stubgen was unable to generate stubs.")
+	"The Python bindings were built successfully, but pybind11-stubgen was unable to generate stubs.")
     endif()
   endif()
 
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})
-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} OPTIONAL FILES_MATCHING PATTERN "*.pyi")
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} OPTIONAL FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
   set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
… output files when that tool is installed

# Description

Basically, if `pybind11-stubgen` is available and a package calls `daq_add_python_bindings`, `pybind11-stubgen` will be called to generate `*.pyi` files to sit alongside the other files in the relevant install directory (e.g., `$DBT_AREA_ROOT/install/conffwk/lib64/python/conffwk`). 

I'm adding this change since Pawel and James wish to use `pybind11-stubgen` to install a kind of type checking in Python. 

To test, create a work area, and clone `daq-cmake` on this feature branch in $DBT_AREA_ROOT/sourcecode. Also clone one (or more) packages with Python bindings. See what happens when you run `dbt-build`, both with and without `pybind11-stubgen` locally installed. 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist
These are inapplicable to daq-cmake. 

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

