### PR TITLE
Johnfreeman/daq cmake issue174 install pyi files

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -905,6 +905,9 @@ function(daq_add_python_bindings)
 
     add_dependencies( ${libname} ${PRE_BUILD_STAGE_DONE_TRGT})
 
+    # JCF, Jul-24-2026, TODO: determine if we should have the output
+    # dir be python/${PROJECT_NAME}_DAL if it's a DAL library
+
     _daq_set_target_output_dirs( ${libname} python/${PROJECT_NAME} )
   else()
     message(FATAL_ERROR "ERROR: No source files found for python library: ${libname}.")
@@ -921,22 +924,39 @@ function(daq_add_python_bindings)
     # of package>" we'll need this code available in the build area
 
     file(COPY
-      ${CMAKE_CURRENT_SOURCE_DIR}/python/${PROJECT_NAME}
-      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python
+      ${srcdir}/
+      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}
     )
 
     set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
-    add_custom_command(
-      OUTPUT
-      ${PRIMARY_STUB_FILE}
-      COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
-      DEPENDS ${libname}
-    )
+
+    # JCF, Jul-24-2026: see my TODO comment above, from this same day
+    if(NOT ${BINDOPTS_DAL})
+
+      add_custom_command(
+	OUTPUT
+	${PRIMARY_STUB_FILE}
+	COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+	DEPENDS ${libname}
+      )
+
+    else()
+
+      add_custom_command(
+	OUTPUT
+	${PRIMARY_STUB_FILE}
+	COMMAND ln -s ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/${libname}.so ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}_dal/${libname}.so
+	COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+	DEPENDS ${libname}
+      )
+    endif()
+
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}/ DESTINATION ${destdir} FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
 
     add_custom_target(${PROJECT_NAME}_pybind11_stubs ALL DEPENDS ${PRIMARY_STUB_FILE})
     add_dependencies(${PROJECT_NAME}_pybind11_stubs ${libname})
 
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
+
   endif()
 
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -929,7 +929,7 @@ function(daq_add_python_bindings)
     add_custom_command(
       OUTPUT
       ${PRIMARY_STUB_FILE}
-      COMMAND ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+      COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
       DEPENDS ${libname}
     )
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -945,7 +945,7 @@ function(daq_add_python_bindings)
       add_custom_command(
 	OUTPUT
 	${PRIMARY_STUB_FILE}
-	COMMAND ln -s ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/${libname}.so ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}_dal/${libname}.so
+	COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/${libname}.so ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}_dal/${libname}.so
 	COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
 	DEPENDS ${libname}
       )

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -913,23 +913,26 @@ function(daq_add_python_bindings)
   find_program(PYBIND11_STUBGEN pybind11-stubgen)
 
   if(PYBIND11_STUBGEN)
-    execute_process(
-      COMMAND ${PYBIND11_STUBGEN} -o ${PROJECT_NAME}/python ${PROJECT_NAME}
-      RESULT_VARIABLE retval
-      ERROR_VARIABLE errmsg
-    )
+        set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
+	add_custom_command(
+		OUTPUT
+		${PRIMARY_STUB_FILE}
+   	      COMMAND PYTHONPATH ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME} ${PYBIND11_STUBGEN} -o ${PROJECT_NAME}/python ${DEFAULT_LINK_LIBRARY}
+	      DEPENDS ${libname}
+          )
 
-    if(retval)
-      message(WARNING
-	"pybind11-stubgen failed for ${PROJECT_NAME}.\n"
-	"${errmsg}\n"
-	"The Python bindings were built successfully, but pybind11-stubgen was unable to generate stubs.")
-    endif()
+      add_custom_target(${PROJECT_NAME}_pybind11_stubs DEPENDS ${PRIMARY_STUB_FILE})
+      add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_pybind11_stubs)
   endif()
+
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
+
+  endif()
+
 
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})
-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} OPTIONAL FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
   set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
 
 endfunction()

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -915,6 +915,16 @@ function(daq_add_python_bindings)
   find_program(PYBIND11_STUBGEN pybind11-stubgen)
 
   if(PYBIND11_STUBGEN)
+
+    # Usually we copy the Python code straight from the source area to
+    # the install area, but since pybind11-stubgen calls "import <name
+    # of package>" we'll need this code available in the build area
+
+    file(COPY
+      ${CMAKE_CURRENT_SOURCE_DIR}/python/${PROJECT_NAME}
+      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python
+    )
+
     set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
     add_custom_command(
       OUTPUT

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -800,7 +800,7 @@ endfunction()
 ####################################################################################################
 # daq_add_python_bindings:
 # Usage:
-# daq_add_python_bindings( <file | glob expression 1> ... [DAL] [LINK_LIBRARIES <lib1> ...])
+# daq_add_python_bindings( <file | glob expression 1> ... [DAL] [GENERATE_STUBS] [LINK_LIBRARIES <lib1> ...])
 #
 
 # daq_add_python_bindings is designed to produce a library providing a
@@ -832,9 +832,12 @@ endfunction()
 # python/${PROJECT_NAME}_dal/__init__.py file which imports
 # _daq_${PROJECT_NAME}_dal_py.so
 
+# GENERATE_STUBS is used if you want daq_add_python_bindings to call
+# pybind11-stubgen to generate *.pyi files off of the Python bindings
+
 function(daq_add_python_bindings)
 
-  cmake_parse_arguments(BINDOPTS "DAL" "" "LINK_LIBRARIES" ${ARGN})
+  cmake_parse_arguments(BINDOPTS "DAL;GENERATE_STUBS" "" "LINK_LIBRARIES" ${ARGN})
 
   if (NOT ${BINDOPTS_DAL})
     set(libname _daq_${PROJECT_NAME}_py)
@@ -915,48 +918,51 @@ function(daq_add_python_bindings)
 
   _daq_define_exportname()
 
-  find_program(PYBIND11_STUBGEN pybind11-stubgen)
+  if(BINDOPTS_GENERATE_STUBS)
 
-  if(PYBIND11_STUBGEN)
+    find_program(PYBIND11_STUBGEN pybind11-stubgen)
 
-    # Usually we copy the Python code straight from the source area to
-    # the install area, but since pybind11-stubgen calls "import <name
-    # of package>" we'll need this code available in the build area
+    if (PYBIND11_STUBGEN)
+    
+      # Usually we copy the Python code straight from the source area to
+      # the install area, but since pybind11-stubgen calls "import <name
+      # of package>" we'll need this code available in the build area
 
-    file(COPY
-      ${srcdir}/
-      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}
-    )
-
-    set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
-
-    # JCF, Jul-24-2026: see my TODO comment above, from this same day
-    if(NOT ${BINDOPTS_DAL})
-
-      add_custom_command(
-	OUTPUT
-	${PRIMARY_STUB_FILE}
-	COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
-	DEPENDS ${libname}
+      file(COPY
+	${srcdir}/
+	DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}
       )
 
+      set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
+
+      # JCF, Jul-24-2026: see my TODO comment above, from this same day
+      if(NOT ${BINDOPTS_DAL})
+
+	add_custom_command(
+	  OUTPUT
+	  ${PRIMARY_STUB_FILE}
+	  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+	  DEPENDS ${libname}
+	)
+
+      else()
+
+	add_custom_command(
+	  OUTPUT
+	  ${PRIMARY_STUB_FILE}
+	  COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/${libname}.so ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}_dal/${libname}.so
+	  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+	  DEPENDS ${libname}
+	)
+      endif()
+
+      install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}/ DESTINATION ${destdir} FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
+
+      add_custom_target(${PROJECT_NAME}_pybind11_stubs ALL DEPENDS ${PRIMARY_STUB_FILE})
+      add_dependencies(${PROJECT_NAME}_pybind11_stubs ${libname})
     else()
-
-      add_custom_command(
-	OUTPUT
-	${PRIMARY_STUB_FILE}
-	COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/${libname}.so ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}_dal/${libname}.so
-	COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
-	DEPENDS ${libname}
-      )
+      message(FATAL_ERROR "GENERATE_STUBS passed as option, but pybind11-stubgen was not found")
     endif()
-
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${DEFAULT_LINK_LIBRARY}/ DESTINATION ${destdir} FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
-
-    add_custom_target(${PROJECT_NAME}_pybind11_stubs ALL DEPENDS ${PRIMARY_STUB_FILE})
-    add_dependencies(${PROJECT_NAME}_pybind11_stubs ${libname})
-
-
   endif()
 
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -910,29 +910,27 @@ function(daq_add_python_bindings)
     message(FATAL_ERROR "ERROR: No source files found for python library: ${libname}.")
   endif()
 
+  _daq_define_exportname()
+
   find_program(PYBIND11_STUBGEN pybind11-stubgen)
 
   if(PYBIND11_STUBGEN)
-        set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
-	add_custom_command(
-		OUTPUT
-		${PRIMARY_STUB_FILE}
-   	      COMMAND PYTHONPATH ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME} ${PYBIND11_STUBGEN} -o ${PROJECT_NAME}/python ${DEFAULT_LINK_LIBRARY}
-	      DEPENDS ${libname}
-          )
+    set(PRIMARY_STUB_FILE ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/__init__.pyi)
+    add_custom_command(
+      OUTPUT
+      ${PRIMARY_STUB_FILE}
+      COMMAND ${PYBIND11_STUBGEN} -o ${CMAKE_CURRENT_BINARY_DIR}/python ${DEFAULT_LINK_LIBRARY}
+      DEPENDS ${libname}
+    )
 
-      add_custom_target(${PROJECT_NAME}_pybind11_stubs DEPENDS ${PRIMARY_STUB_FILE})
-      add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_pybind11_stubs)
+    add_custom_target(${PROJECT_NAME}_pybind11_stubs ALL DEPENDS ${PRIMARY_STUB_FILE})
+    add_dependencies(${PROJECT_NAME}_pybind11_stubs ${libname})
+
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${destdir} FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
   endif()
 
-
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/${PROJECT_NAME}/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "*.pyi" PATTERN "py.typed")
-
-  endif()
-
-
-  _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${destdir})
+
   set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
 
 endfunction()

--- a/docs/README.md
+++ b/docs/README.md
@@ -273,7 +273,7 @@ Its compilation will be done automatically, i.e. there is no need to add `*.pb.c
 ### daq_add_python_bindings:
 Usage:
 ```
-daq_add_python_bindings( <file | glob expression 1> ... [DAL] [LINK_LIBRARIES <lib1> ...])
+daq_add_python_bindings( <file | glob expression 1> ... [DAL] [GENERATE_STUBS] [LINK_LIBRARIES <lib1> ...])
 ```
 
 `daq_add_python_bindings` is designed to produce a library providing a Python
@@ -299,6 +299,11 @@ See `toylibrary` for a working example.
 _With_ the `DAL` option, the library shared object will be `_daq_${PROJECT_NAME}_dal_py.so`,
 and will be installed in the `python/${PROJECT_NAME}_dal` directory. Here, you need a
 `python/${PROJECT_NAME}_dal/__init__.py` file which imports `_daq_${PROJECT_NAME}_dal_py.so`.
+
+`GENERATE_STUBS` is used if you want `daq_add_python_bindings` to call
+`pybind11-stubgen` to generate `*.pyi` files off of the Python
+bindings
+
 
 ### daq_add_plugin:
 Usage:


### PR DESCRIPTION
# Description

With this PR, if you pass a `GENERATE_STUBS` option to `daq_add_python_bindings`, the function will use `pybind11-stubgen` to generate `*.pyi` files off the bindings. This enables `mypy` to engage in a kind of type checking for Python code. See issue #174 for details.

To test, I've created a [test build](https://github.com/DUNE-DAQ/daq-release/actions/runs/30928542308) using this feature branch, `MYPYFD_DEV_260804_A9` which passes the [standard](https://github.com/DUNE-DAQ/daq-release/actions/runs/30941847810) and [extended](https://github.com/DUNE-DAQ/daq-release/actions/runs/30946486620) integration tests. Note in the test build that `GENERATE_STUBS` was only passed to `daq_add_python_bindings` in `conffwk` and `confgen`; you can look for `*.pyi` files in those installations. Also looking for (official) confirmation from Pawel that the `*.pyi` files are accomplishing what CCM/Python developers are hoping for. Note I've added brief documentation both in the `README.md` and in-code comments. 

## Type of change

- [X ] Documentation (non-breaking change that adds or improves the documentation)
- [X ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [X ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Of course, some of the above is N/A to a daq-cmake change. 

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

